### PR TITLE
Derecursive preprocessing, no more keepRunning

### DIFF
--- a/lib/preprocessor.js
+++ b/lib/preprocessor.js
@@ -8,8 +8,8 @@ const crRegex = /[\r\n ]+$/g;
  * @param  {Object} node     AST node to bracket
  * @return {String}          contract
  */
-function blockWrap(contract, expression) {
-  return contract.slice(0, expression.start) + '{' + contract.slice(expression.start, expression.end) + '}' + contract.slice(expression.end);
+function blockWrap(contract, expression, offset) {
+  return contract.slice(0, expression.start + offset) + '{' + contract.slice(expression.start + offset, expression.end + offset) + '}' + contract.slice(expression.end + offset);
 }
 
 
@@ -20,10 +20,11 @@ function blockWrap(contract, expression) {
  * @param  {Object} modifier AST node
  * @return {String} whitespace around the modifier
  */
-function getModifierWhitespace(contract,  modifier){
+function getModifierWhitespace(contract, modifier) {
   const source = contract.slice(modifier.start, modifier.end);
   const whitespace = source.match(crRegex) || [];
-  return whitespace.join('');
+  const space = whitespace.join('');
+  return ' '.repeat(modifier.end - modifier.start - space.length) + space;
 }
 
 /**
@@ -38,55 +39,61 @@ function getModifierWhitespace(contract,  modifier){
  * @return {String}          contract
  */
 module.exports.run = function r(contract) {
-  let keepRunning = true;
+  let offset = 0;
+  try {
+    const ast = SolidityParser.parse(contract);
+    SolExplore.traverse(ast, {
+      leave(node, parent) {
+        if (node.wrap) {
+          offset += 1;
+        }
+      },
 
-  while (keepRunning) {
-    try {
-      const ast = SolidityParser.parse(contract);
-      keepRunning = false;
-      SolExplore.traverse(ast, {
-        enter(node, parent) { // eslint-disable-line no-loop-func
-          // If consequents
-          if (node.type === 'IfStatement' && node.consequent.type !== 'BlockStatement') {
-            contract = blockWrap(contract, node.consequent);
-            keepRunning = true;
-            this.stopTraversal();
-          // If alternates
-          } else if (
-              node.type === 'IfStatement' &&
-              node.alternate &&
-              node.alternate.type !== 'BlockStatement') {
-            contract = blockWrap(contract, node.alternate);
-            keepRunning = true;
-            this.stopTraversal();
-          // Loops
-          } else if (
-              (node.type === 'ForStatement' || node.type === 'WhileStatement') &&
-              node.body.type !== 'BlockStatement') {
-            contract = blockWrap(contract, node.body);
-            keepRunning = true;
-            this.stopTraversal();
-          } else if (node.type === 'FunctionDeclaration' && node.modifiers) {
-            // We want to remove constant / pure / view from functions
-            for (let i = 0; i < node.modifiers.length; i++) {
-              if (['pure', 'constant', 'view'].indexOf(node.modifiers[i].name) > -1) {
-                let whitespace = getModifierWhitespace(contract, node.modifiers[i]);
-
-                contract = contract.slice(0, node.modifiers[i].start) +
-                           whitespace +
-                           contract.slice(node.modifiers[i].end);
-
-                keepRunning = true;
-                this.stopTraversal();
-              }
-            }
-          }
-        },
-      });
-    } catch (err) {
-      contract = err;
-      keepRunning = false;
-    }
+      enter(node, parent) { // eslint-disable-line no-loop-func
+        // If consequents
+        if (node.type === 'IfStatement' && node.consequent.type !== 'BlockStatement') {
+          contract = blockWrap(contract, node.consequent, offset);
+          offset += 1;
+          node.wrap = true;
+        // If alternates
+        } else if (
+            node.type === 'IfStatement' &&
+            node.alternate &&
+            node.alternate.type !== 'BlockStatement') {
+          contract = blockWrap(contract, node.alternate, offset);
+          offset += 1;
+          node.wrap = true;
+        // Loops
+        } else if (
+            (node.type === 'ForStatement' || node.type === 'WhileStatement') &&
+            node.body.type !== 'BlockStatement') {
+          contract = blockWrap(contract, node.body, offset);
+          offset += 1;
+          node.wrap = true;
+        }
+      },
+    });
+  } catch (err) {
+    contract = err;
   }
+
+  const ast = SolidityParser.parse(contract);
+  SolExplore.traverse(ast, {
+    enter(node, parent) {
+      if (node.type === 'FunctionDeclaration' && node.modifiers) {
+        // We want to remove constant / pure / view from functions
+        for (let i = 0; i < node.modifiers.length; i++) {
+          if (['pure', 'constant', 'view'].indexOf(node.modifiers[i].name) > -1) {
+            const whitespace = getModifierWhitespace(contract, node.modifiers[i]);
+
+            contract = contract.slice(0, node.modifiers[i].start) +
+                      whitespace +
+                      contract.slice(node.modifiers[i].end);
+          }
+        }
+      }
+    },
+  });
+
   return contract;
 };


### PR DESCRIPTION
@pinkiebell 
- Make coverage run as fast as it could
- Save dev and CI time
- In my computer, it saves 4 minutes each run

Demo is https://github.com/leapdao/solEVM-enforcer/pull/85